### PR TITLE
JsonConverter reader implementation

### DIFF
--- a/CapMonsterCloud.Client.Tests/JsonConverterTests.cs
+++ b/CapMonsterCloud.Client.Tests/JsonConverterTests.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using Zennolab.CapMonsterCloud.Requests;
+
+namespace Zennolab.CapMonsterCloud.Client
+{
+    public class JsonConverterTests
+    {
+        [Test]
+        public void NumericFlagConverter_ShouldDeserialize([Values] bool numeric)
+        {
+            // Arrange
+            var target = new ImageToTextRequest
+            {
+                Body = "some base64 body",
+                CapMonsterModule = CapMonsterModules.YandexWave,
+                CaseSensitive = true,
+                Numeric = numeric,
+                RecognizingThreshold = 65,
+                Math = false
+            };
+
+            // Act
+            var actual = JsonConvert.SerializeObject(target);
+            var result = JsonConvert.DeserializeObject<ImageToTextRequest>(actual);
+
+            // Assert
+            result.Numeric.Should().Be(target.Numeric);
+        }
+
+        [Test]
+        public void DictionaryToSemicolonSplittedStringConverter_ShouldDeserialize()
+        {
+            // Arrange
+            var cookies = new Dictionary<string, string>
+            {
+                { "cookieA", "value#A" },
+                { "cookieB", "value#B" }
+            };
+
+            var target = new HCaptchaProxylessRequest
+            {
+                WebsiteUrl = "https://lessons.zennolab.com/captchas/hcaptcha/?level=easy",
+                WebsiteKey = "472fc7af-86a4-4382-9a49-ca9090474471",
+                Invisible = false,
+                Data = "some data",
+                UserAgent = "PostmanRuntime/7.29.0",
+                Cookies = cookies
+            };
+
+            // Act
+            var actual = JsonConvert.SerializeObject(target);
+            var result = JsonConvert.DeserializeObject<HCaptchaProxylessRequest>(actual);
+
+            // Assert
+            result.Cookies.Should().ContainKeys(cookies.Keys);
+            result.Cookies.Should().ContainValues(cookies.Values);
+        }
+
+        [Test]
+        public void DictionaryToSemicolonSplittedStringConverter_ShouldThrowJsonReaderException()
+        {
+            // Arrange
+            var target = JsonConvert.SerializeObject(
+                new
+                {
+                    type = "HCaptchaTaskProxyless",
+                    websiteURL = "https://lessons.zennolab.com/captchas/hcaptcha/?level=easy",
+                    websiteKey = "472fc7af-86a4-4382-9a49-ca9090474471",
+                    isInvisible = false,
+                    data = "some data",
+                    userAgent = "PostmanRuntime/7.29.0",
+                    cookies = "some invalid cookie string"
+                });
+
+            // Act
+            Func<HCaptchaProxylessRequest> act = () => JsonConvert.DeserializeObject<HCaptchaProxylessRequest>(target);
+
+            // Assert
+            _ = act.Should().Throw<JsonReaderException>();
+        }
+    }
+}

--- a/CapMonsterCloud.Client.Tests/JsonConverterTests.cs
+++ b/CapMonsterCloud.Client.Tests/JsonConverterTests.cs
@@ -13,7 +13,7 @@ namespace Zennolab.CapMonsterCloud.Client
         public void NumericFlagConverter_ShouldDeserialize([Values] bool numeric)
         {
             // Arrange
-            var target = new ImageToTextRequest
+            var request = new ImageToTextRequest
             {
                 Body = "some base64 body",
                 CapMonsterModule = CapMonsterModules.YandexWave,
@@ -23,41 +23,41 @@ namespace Zennolab.CapMonsterCloud.Client
                 Math = false
             };
 
+            var target = JsonConvert.SerializeObject(request);
+
             // Act
-            var actual = JsonConvert.SerializeObject(target);
-            var result = JsonConvert.DeserializeObject<ImageToTextRequest>(actual);
+            var actual = JsonConvert.DeserializeObject<ImageToTextRequest>(target);
 
             // Assert
-            result.Numeric.Should().Be(target.Numeric);
+            _ = actual.Numeric.Should().Be(request.Numeric);
         }
 
         [Test]
         public void DictionaryToSemicolonSplittedStringConverter_ShouldDeserialize()
         {
             // Arrange
-            var cookies = new Dictionary<string, string>
-            {
-                { "cookieA", "value#A" },
-                { "cookieB", "value#B" }
-            };
-
-            var target = new HCaptchaProxylessRequest
+            var request = new HCaptchaProxylessRequest
             {
                 WebsiteUrl = "https://lessons.zennolab.com/captchas/hcaptcha/?level=easy",
                 WebsiteKey = "472fc7af-86a4-4382-9a49-ca9090474471",
                 Invisible = false,
                 Data = "some data",
                 UserAgent = "PostmanRuntime/7.29.0",
-                Cookies = cookies
+                Cookies = new Dictionary<string, string>
+                {
+                    { "cookieA", "value#A" },
+                    { "cookieB", "value#B" }
+                }
             };
 
+            var target = JsonConvert.SerializeObject(request);
+
             // Act
-            var actual = JsonConvert.SerializeObject(target);
-            var result = JsonConvert.DeserializeObject<HCaptchaProxylessRequest>(actual);
+            var actual = JsonConvert.DeserializeObject<HCaptchaProxylessRequest>(target);
 
             // Assert
-            result.Cookies.Should().ContainKeys(cookies.Keys);
-            result.Cookies.Should().ContainValues(cookies.Values);
+            _ = actual.Cookies.Should().ContainKeys(request.Cookies.Keys);
+            _ = actual.Cookies.Should().ContainValues(request.Cookies.Values);
         }
 
         [Test]

--- a/CapMonsterCloud.Client.Tests/RequestsSerializationTests.cs
+++ b/CapMonsterCloud.Client.Tests/RequestsSerializationTests.cs
@@ -44,7 +44,7 @@ namespace Zennolab.CapMonsterCloud.Client
         }
 
         [Test]
-        public void RecaptchaV2Request__ShouldSerialize([Values]ProxyType proxyType)
+        public void RecaptchaV2Request__ShouldSerialize([Values] ProxyType proxyType)
         {
             // Arrange
             var target = new RecaptchaV2Request
@@ -211,7 +211,7 @@ namespace Zennolab.CapMonsterCloud.Client
         }
 
         [Test]
-        public void HCaptchaProxylessRequest__ShouldSerialize([Values]bool invisible)
+        public void HCaptchaProxylessRequest__ShouldSerialize([Values] bool invisible)
         {
             // Arrange
             var target = new HCaptchaProxylessRequest
@@ -225,7 +225,7 @@ namespace Zennolab.CapMonsterCloud.Client
                 {
                     { "cookieA", "value#A" },
                     { "cookieB", "value#B" }
-                },
+                }
             };
 
             // Act

--- a/CapMonsterCloud.Client/CapMonsterCloud.Client.csproj
+++ b/CapMonsterCloud.Client/CapMonsterCloud.Client.csproj
@@ -15,8 +15,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/ZennoLab/capmonstercloud-client-dotnet</RepositoryUrl>
-    <Version>1.1.5</Version>
-    <PackageReleaseNotes>Fixed README: added RecaptchaV2EnterpriseRequest and RecaptchaV2EnterpriseProxylessRequest</PackageReleaseNotes>
+    <Version>1.1.6</Version>
+    <PackageReleaseNotes>Improved request models serialization\deserialization. HCaptchaRequest implements IProxyInfo</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CapMonsterCloud.Client/Json/DictionaryToSemicolonSplittedStringConverter.cs
+++ b/CapMonsterCloud.Client/Json/DictionaryToSemicolonSplittedStringConverter.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Zennolab.CapMonsterCloud.Json
 {
@@ -12,7 +13,17 @@ namespace Zennolab.CapMonsterCloud.Json
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            var value = reader.Value?.ToString();
+            var regexValidation = new Regex("^((.*)(=?){2};?)+$");
+
+            if (regexValidation.IsMatch(value))
+                return value.Split(';').Select(item =>
+                {
+                    var keyValueItem = item.Split('=');
+                    return new KeyValuePair<string, string>(keyValueItem[0], keyValueItem[1]);
+                }).ToDictionary(x => x.Key, x => x.Value);
+
+            throw new JsonReaderException();
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/CapMonsterCloud.Client/Json/DictionaryToSemicolonSplittedStringConverter.cs
+++ b/CapMonsterCloud.Client/Json/DictionaryToSemicolonSplittedStringConverter.cs
@@ -17,11 +17,15 @@ namespace Zennolab.CapMonsterCloud.Json
             var regexValidation = new Regex("^((.*)(=?){2};?)+$");
 
             if (regexValidation.IsMatch(value))
-                return value.Split(';').Select(item =>
+                try
                 {
-                    var keyValueItem = item.Split('=');
-                    return new KeyValuePair<string, string>(keyValueItem[0], keyValueItem[1]);
-                }).ToDictionary(x => x.Key, x => x.Value);
+                    return value.Split(';').Select(item =>
+                    {
+                        var keyValueItem = item.Split('=');
+                        return new KeyValuePair<string, string>(keyValueItem[0], keyValueItem[1]);
+                    }).ToDictionary(x => x.Key, x => x.Value);
+                }
+                catch (Exception) { }
 
             throw new JsonReaderException();
         }

--- a/CapMonsterCloud.Client/Json/NumericFlagConverter.cs
+++ b/CapMonsterCloud.Client/Json/NumericFlagConverter.cs
@@ -8,14 +8,10 @@ namespace Zennolab.CapMonsterCloud.Json
         public override bool CanConvert(Type objectType)
             => objectType == typeof(bool);
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
+            Convert.ToBoolean(reader.Value);
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) =>
             writer.WriteValue((bool)value ? 1 : 0);
-        }
     }
 }

--- a/CapMonsterCloud.Client/Requests/HCaptchaRequest.cs
+++ b/CapMonsterCloud.Client/Requests/HCaptchaRequest.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.ComponentModel.DataAnnotations;
 
 namespace Zennolab.CapMonsterCloud.Requests
 {
@@ -9,7 +10,7 @@ namespace Zennolab.CapMonsterCloud.Requests
     /// <example>
     /// https://zennolab.atlassian.net/wiki/spaces/APIS/pages/1203240988/HCaptchaTask+hCaptcha+puzzle+solving
     /// </example>
-    public sealed class HCaptchaRequest : HCaptchaRequestBase
+    public sealed class HCaptchaRequest : HCaptchaRequestBase, IProxyInfo
     {
         /// <summary>
         /// Recognition task type
@@ -31,6 +32,7 @@ namespace Zennolab.CapMonsterCloud.Requests
 
         /// <inheritdoc/>
         [JsonProperty("proxyPort", Required = Required.Always)]
+        [Range(0, 65535)]
         public int ProxyPort { get; set; }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Reader implementation in JsonConverter for DictionaryToSemicolonSplittedStringConverter and NumericFlagConverter.
Useful for serialization and deserialization process when data is persisted in a database, for example.
